### PR TITLE
use shaded version of netty to avoid conflicts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,8 @@ lazy val scalligraphJanusgraph = (project in file("database/janusgraph"))
 //      janusGraphHBase,
       janusGraphLucene,
       janusGraphElasticSearch,
-      janusGraphCassandra,
+      janusGraphCassandra exclude (cassandraDriverShaded.organization, cassandraDriverShaded.name),
+      cassandraDriverShaded,
 //      janusGraphDriver,
 //      janusGraphCore,
       specs % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,7 @@ object Dependencies {
   lazy val janusGraphLucene        = "org.janusgraph"            % "janusgraph-lucene"                  % janusVersion
   lazy val janusGraphElasticSearch = "org.janusgraph"            % "janusgraph-es"                      % janusVersion
   lazy val janusGraphCassandra     = "org.janusgraph"            % "janusgraph-cql"                     % janusVersion
+  lazy val cassandraDriverShaded   = "com.datastax.cassandra"    % "cassandra-driver-core"              % "3.9.0" classifier "shaded" exclude("io.netty", "*") // align with janusgraph-cql
   lazy val janusGraphInMemory      = "org.janusgraph"            % "janusgraph-inmemory"                % janusVersion
   lazy val tinkerpop               = "org.apache.tinkerpop"      % "gremlin-core"                       % "3.4.6"         // align with janusgraph
   lazy val scalactic               = "org.scalactic"            %% "scalactic"                          % "3.2.3"


### PR DESCRIPTION
This forces cassandra to use its own version of netty and will avoid conflicts with other version of netty from other libs