### PR TITLE
Use textContains instead of textContainsRegex

### DIFF
--- a/database/janusgraph/src/main/scala/org/thp/scalligraph/janus/JanusDatabase.scala
+++ b/database/janusgraph/src/main/scala/org/thp/scalligraph/janus/JanusDatabase.scala
@@ -494,8 +494,8 @@ class JanusDatabase(
 
   override def mapPredicate[T](predicate: P[T]): P[T] =
     predicate.getBiPredicate match {
-      case Text.containing    => JanusText.textContainsRegex(s".*${predicate.getValue}.*").asInstanceOf[P[T]]
-      case Text.notContaining => JanusText.textContainsRegex(s".*${predicate.getValue}.*").negate().asInstanceOf[P[T]]
+      case Text.containing    => JanusText.textContains(s"${predicate.getValue}").asInstanceOf[P[T]]
+      case Text.notContaining => JanusText.textContains(s"${predicate.getValue}").negate().asInstanceOf[P[T]]
       //      case Text.endingWith      => JanusText.textRegex(s"${predicate.getValue}.*")
       //      case Text.notEndingWith   => JanusText.textRegex(s"${predicate.getValue}.*").negate()
       case Text.startingWith    => JanusText.textPrefix(predicate.getValue)


### PR DESCRIPTION
With this change more results are returned from the search and the terms are more case insensitive.

Before if you had a field with values: `Bar Foo bar`, ` bar foo`, `BAR FOO`, only a query with `foo` would return all results. A query with `FOO` would not return results.

Now, a query with `foo` or `FOO` will return the 3 results.