### PR TITLE
Make scalligraph use play.http.context properly

### DIFF
--- a/core/src/main/scala/org/thp/scalligraph/ScalligraphApplication.scala
+++ b/core/src/main/scala/org/thp/scalligraph/ScalligraphApplication.scala
@@ -175,6 +175,7 @@ class ScalligraphApplicationImpl(val context: Context)
 
   val routers: LazyMutableSeq[Router] = LazyMutableSeq[Router]
   override lazy val router: Router = initCheck {
+    val prefix = httpConfiguration.context
     routers()
       .reduceOption(_ orElse _)
       .getOrElse(Router.empty)
@@ -183,6 +184,7 @@ class ScalligraphApplicationImpl(val context: Context)
           case _ => authAction
         }
       }
+      .withPrefix(prefix)
   }
 
   lazy val defaultAction: ActionFunction[Request, AuthenticatedRequest] = new ActionFunction[Request, AuthenticatedRequest] {


### PR DESCRIPTION
When using dependency injection with Guice, the `Provider[Router]` was automatically picking up the current http context. (https://github.com/playframework/playframework/blob/master/core/play/src/main/scala/play/api/inject/BuiltinModule.scala#L117) 

This was not the case with the current implementation.

So now when the config `play.http.context` is provided to the application, the router will be prefixed with this configuration (like it did with Guice). 